### PR TITLE
test deploy

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -117,12 +117,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, "static"),
-)
 logger.debug(f"BASE_DIR: {BASE_DIR}")
 logger.debug(f"static_root: {STATIC_ROOT}")
-logger.debug(f"staticfiles_dirs: {STATICFILES_DIRS}")
 
 
 # markdown
@@ -157,6 +153,10 @@ if DEBUG:
     DATABASES = {
         'default': env.db()
     }
+
+    STATICFILES_DIRS = (
+        os.path.join(BASE_DIR, "static"),
+    )
 
     ALLOWED_HOSTS = ['localhost']
 else:


### PR DESCRIPTION
herokuにデプロイしても静的ファイルが読み込まれないため、
テスト用にSTATIC_DIRECTORYデバッグの時にだけ適用